### PR TITLE
fix: make AnyEnter fire on NumpadEnter

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ Additionally, Sørensen allows special, "virtual" codes, for conveniance when us
 | `Option`     | `AltLeft`, `AltRight`                                                             |
 | `Command`    | `OSLeft`, `OSRight`                                                               |
 | `Windows`    | `OSLeft`, `OSRight`                                                               |
-| `Accel`      | on a Mac-like sytstem: `OSLeft`, `OSRight`, others: `ControlLeft`, `ControlRight` |
+| `Accel`      | on a Mac-like system: `OSLeft`, `OSRight`, others: `ControlLeft`, `ControlRight`  |

--- a/src/__tests__/bind.test.ts
+++ b/src/__tests__/bind.test.ts
@@ -576,6 +576,85 @@ describe('Sørensen.bind', () => {
 				})
 			})
 		})
+
+		describe('metacodes', () => {
+			it('Shift fires when pressing ShiftLeft and ShiftRight', async () => {
+				await bindCombo('Shift')
+				await expectToTrigger('Shift', 0)
+
+				await page.keyboard.press('ShiftLeft')
+				await expectToTrigger('Shift', 1)
+
+				await page.keyboard.press('ShiftRight')
+				await expectToTrigger('Shift', 2)
+			})
+
+			it('Ctrl fires when pressing ControlLeft and ControlRight', async () => {
+				await bindCombo('Ctrl')
+				await expectToTrigger('Ctrl', 0)
+
+				await page.keyboard.press('ControlLeft')
+				await expectToTrigger('Ctrl', 1)
+
+				await page.keyboard.press('ControlRight')
+				await expectToTrigger('Ctrl', 2)
+			})
+
+			it('Control fires when pressing ControlLeft and ControlRight', async () => {
+				await bindCombo('Control')
+				await expectToTrigger('Control', 0)
+
+				await page.keyboard.press('ControlLeft')
+				await expectToTrigger('Control', 1)
+
+				await page.keyboard.press('ControlRight')
+				await expectToTrigger('Control', 2)
+			})
+
+			it('Alt fires when pressing AltLeft and AltRight', async () => {
+				await bindCombo('Alt')
+				await expectToTrigger('Alt', 0)
+
+				await page.keyboard.press('AltLeft')
+				await expectToTrigger('Alt', 1)
+
+				await page.keyboard.press('AltRight')
+				await expectToTrigger('Alt', 2)
+			})
+
+			it('Meta fires when pressing MetaLeft and MetaRight', async () => {
+				await bindCombo('Meta')
+				await expectToTrigger('Meta', 0)
+
+				await page.keyboard.press('MetaLeft')
+				await expectToTrigger('Meta', 1)
+
+				await page.keyboard.press('MetaRight')
+				await expectToTrigger('Meta', 2)
+			})
+
+			it('AnyEnter fires when pressing Enter and NumpadEnter', async () => {
+				await bindCombo('AnyEnter')
+				await expectToTrigger('AnyEnter', 0)
+
+				await page.keyboard.press('Enter')
+				await expectToTrigger('AnyEnter', 1)
+
+				await page.keyboard.press('NumpadEnter')
+				await expectToTrigger('AnyEnter', 2)
+			})
+
+			it('Option fires when pressing AltLeft and AltRight', async () => {
+				await bindCombo('Option')
+				await expectToTrigger('Option', 0)
+
+				await page.keyboard.press('AltLeft')
+				await expectToTrigger('Option', 1)
+
+				await page.keyboard.press('AltRight')
+				await expectToTrigger('Option', 2)
+			})
+		})
 	})
 
 	describe('keyup', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,7 @@ export const VIRTUAL_ANY_POSITION_KEYS: Record<string, string[]> = {
 	Ctrl: ['ControlLeft', 'ControlRight'],
 	Alt: ['AltLeft', 'AltRight'],
 	Meta: ['MetaLeft', 'MetaRight'],
-	AnyEnter: ['Enter'],
+	AnyEnter: ['Enter', 'NumpadEnter'],
 	Option: ['AltLeft', 'AltRight'],
 	Command: ['OSLeft', 'OSRight'],
 	Windows: ['OSLeft', 'OSRight'],


### PR DESCRIPTION
Fixes `AnyEnter` to fire on `NumpadEnter`.
Adds basic unit tests for most of the meta-codes from `VIRTUAL_ANY_POSITION_KEYS` (Does not cover anything with `OSLeft`/`OSRight` because puppeteer does not seem to support it).
Fixes typo in README.md