### PR TITLE
feat: add `preventDefaultDown` option - prevent default behavior on `down` events for an `up` Combo.

### DIFF
--- a/src/__tests__/bind.test.ts
+++ b/src/__tests__/bind.test.ts
@@ -1,4 +1,4 @@
-import { bindCombo, expectToTrigger, resetAllCombos } from './utils/bindCombo'
+import { bindCombo, expectToBePrevented, expectToTrigger, resetAllCombos } from './utils/bindCombo'
 
 jest.setTimeout(300000)
 
@@ -786,6 +786,221 @@ describe('Sørensen.bind', () => {
 				await page.keyboard.up('KeyD')
 
 				await expectToTrigger('KeyA+KeyC KeyB+KeyD', 1)
+			})
+		})
+
+		describe('preventDefaultDown', () => {
+			beforeAll(async () => {
+				await bindCombo('Control+KeyD', { preventDefaultDown: true })
+				await bindCombo('KeyA+KeyB', { preventDefaultDown: true })
+				await bindCombo('Control+KeyC Shift+KeyD KeyE', { preventDefaultDown: true })
+			})
+
+			it('Control+KeyD does trigger preventDefault', async () => {
+				await expectToTrigger('Control+KeyD', 0)
+				await expectToBePrevented('Control+KeyD', 0)
+
+				await page.keyboard.down('Control')
+				await expectToTrigger('Control+KeyD', 0)
+				await expectToBePrevented('Control+KeyD', 0)
+				await page.keyboard.down('KeyD')
+				await expectToTrigger('Control+KeyD', 1)
+				await expectToBePrevented('Control+KeyD', 1)
+
+				await page.keyboard.up('Control')
+				await page.keyboard.up('KeyD')
+				await expectToTrigger('Control+KeyD', 1)
+				await expectToBePrevented('Control+KeyD', 1)
+
+				await page.keyboard.down('Control')
+				await expectToTrigger('Control+KeyD', 1)
+				await expectToBePrevented('Control+KeyD', 1)
+				await page.keyboard.down('KeyD')
+				await expectToTrigger('Control+KeyD', 2)
+				await expectToBePrevented('Control+KeyD', 2)
+
+				await page.keyboard.up('Control')
+				await page.keyboard.up('KeyD')
+				await expectToTrigger('Control+KeyD', 2)
+				await expectToBePrevented('Control+KeyD', 2)
+			})
+
+			it('KeyA+KeyB does trigger preventDefault', async () => {
+				await expectToTrigger('KeyA+KeyB', 0)
+				await expectToBePrevented('KeyA+KeyB', 0)
+
+				await page.keyboard.down('KeyA')
+				await expectToTrigger('KeyA+KeyB', 0)
+				await expectToBePrevented('KeyA+KeyB', 0)
+				await page.keyboard.down('KeyB')
+				await expectToTrigger('KeyA+KeyB', 1)
+				await expectToBePrevented('KeyA+KeyB', 1)
+
+				await page.keyboard.up('KeyA')
+				await page.keyboard.up('KeyB')
+				await expectToTrigger('KeyA+KeyB', 1)
+				await expectToBePrevented('KeyA+KeyB', 1)
+
+				await page.keyboard.down('KeyA')
+				await expectToTrigger('KeyA+KeyB', 1)
+				await expectToBePrevented('KeyA+KeyB', 1)
+				await page.keyboard.down('KeyB')
+				await expectToTrigger('KeyA+KeyB', 2)
+				await expectToBePrevented('KeyA+KeyB', 2)
+
+				await page.keyboard.up('KeyA')
+				await page.keyboard.up('KeyB')
+				await expectToTrigger('KeyA+KeyB', 2)
+				await expectToBePrevented('KeyA+KeyB', 2)
+			})
+
+			it('Control+KeyC Shift+KeyD KeyE does trigger preventDefault', async () => {
+				await expectToTrigger('Control+KeyC Shift+KeyD KeyE', 0)
+				await expectToBePrevented('Control+KeyC Shift+KeyD KeyE', 0)
+
+				await page.keyboard.down('Control')
+				await page.keyboard.down('KeyC')
+				await page.keyboard.up('KeyC')
+				await page.keyboard.up('Control')
+
+				await page.keyboard.down('Shift')
+				await page.keyboard.down('KeyD')
+				await page.keyboard.up('KeyD')
+				await page.keyboard.up('Shift')
+
+				await page.keyboard.press('KeyE')
+				await expectToTrigger('Control+KeyC Shift+KeyD KeyE', 1)
+				await expectToBePrevented('Control+KeyC Shift+KeyD KeyE', 1)
+			})
+		})
+
+		describe('No preventDefaultDown', () => {
+			beforeAll(async () => {
+				await bindCombo('Control+KeyD')
+				await bindCombo('KeyA+KeyB')
+			})
+
+			it('Control+KeyD does not trigger preventDefault', async () => {
+				await expectToTrigger('Control+KeyD', 0)
+				await expectToBePrevented('Control+KeyD', 0)
+
+				await page.keyboard.down('Control')
+				await expectToTrigger('Control+KeyD', 0)
+				await expectToBePrevented('Control+KeyD', 0)
+				await page.keyboard.down('KeyD')
+				await expectToTrigger('Control+KeyD', 1)
+				await expectToBePrevented('Control+KeyD', 0)
+
+				await page.keyboard.up('Control')
+				await page.keyboard.up('KeyD')
+				await expectToTrigger('Control+KeyD', 1)
+				await expectToBePrevented('Control+KeyD', 0)
+
+				await page.keyboard.down('Control')
+				await expectToTrigger('Control+KeyD', 1)
+				await expectToBePrevented('Control+KeyD', 0)
+				await page.keyboard.down('KeyD')
+				await expectToTrigger('Control+KeyD', 2)
+				await expectToBePrevented('Control+KeyD', 0)
+
+				await page.keyboard.up('Control')
+				await page.keyboard.up('KeyD')
+				await expectToTrigger('Control+KeyD', 2)
+				await expectToBePrevented('Control+KeyD', 0)
+			})
+
+			it('KeyA+KeyB does not trigger preventDefault', async () => {
+				await expectToTrigger('KeyA+KeyB', 0)
+				await expectToBePrevented('KeyA+KeyB', 0)
+
+				await page.keyboard.down('KeyA')
+				await expectToTrigger('KeyA+KeyB', 0)
+				await expectToBePrevented('KeyA+KeyB', 0)
+				await page.keyboard.down('KeyB')
+				await expectToTrigger('KeyA+KeyB', 1)
+				await expectToBePrevented('KeyA+KeyB', 0)
+
+				await page.keyboard.up('KeyA')
+				await page.keyboard.up('KeyB')
+				await expectToTrigger('KeyA+KeyB', 1)
+				await expectToBePrevented('KeyA+KeyB', 0)
+
+				await page.keyboard.down('KeyA')
+				await expectToTrigger('KeyA+KeyB', 1)
+				await expectToBePrevented('KeyA+KeyB', 0)
+				await page.keyboard.down('KeyB')
+				await expectToTrigger('KeyA+KeyB', 2)
+				await expectToBePrevented('KeyA+KeyB', 0)
+
+				await page.keyboard.up('KeyA')
+				await page.keyboard.up('KeyB')
+				await expectToTrigger('KeyA+KeyB', 2)
+				await expectToBePrevented('KeyA+KeyB', 0)
+			})
+		})
+
+		describe('Explicit no preventDefaultDown', () => {
+			beforeAll(async () => {
+				await bindCombo('Control+KeyD', { preventDefaultDown: false })
+				await bindCombo('KeyA+KeyB', { preventDefaultDown: false })
+			})
+
+			it('Control+KeyD does trigger preventDefault', async () => {
+				await expectToTrigger('Control+KeyD', 0)
+				await expectToBePrevented('Control+KeyD', 0)
+
+				await page.keyboard.down('Control')
+				await expectToTrigger('Control+KeyD', 0)
+				await expectToBePrevented('Control+KeyD', 0)
+				await page.keyboard.down('KeyD')
+				await expectToTrigger('Control+KeyD', 1)
+				await expectToBePrevented('Control+KeyD', 0)
+
+				await page.keyboard.up('Control')
+				await page.keyboard.up('KeyD')
+				await expectToTrigger('Control+KeyD', 1)
+				await expectToBePrevented('Control+KeyD', 0)
+
+				await page.keyboard.down('Control')
+				await expectToTrigger('Control+KeyD', 1)
+				await expectToBePrevented('Control+KeyD', 0)
+				await page.keyboard.down('KeyD')
+				await expectToTrigger('Control+KeyD', 2)
+				await expectToBePrevented('Control+KeyD', 0)
+
+				await page.keyboard.up('Control')
+				await page.keyboard.up('KeyD')
+				await expectToTrigger('Control+KeyD', 2)
+				await expectToBePrevented('Control+KeyD', 0)
+			})
+
+			it('KeyA+KeyB does not trigger preventDefault', async () => {
+				await expectToTrigger('KeyA+KeyB', 0)
+				await expectToBePrevented('KeyA+KeyB', 0)
+
+				await page.keyboard.down('KeyA')
+				await expectToTrigger('KeyA+KeyB', 0)
+				await expectToBePrevented('KeyA+KeyB', 0)
+				await page.keyboard.down('KeyB')
+				await expectToTrigger('KeyA+KeyB', 1)
+				await expectToBePrevented('KeyA+KeyB', 0)
+
+				await page.keyboard.up('KeyA')
+				await page.keyboard.up('KeyB')
+				await expectToTrigger('KeyA+KeyB', 1)
+				await expectToBePrevented('KeyA+KeyB', 0)
+
+				await page.keyboard.down('KeyA')
+				await expectToTrigger('KeyA+KeyB', 1)
+				await expectToBePrevented('KeyA+KeyB', 0)
+				await page.keyboard.down('KeyB')
+				await expectToTrigger('KeyA+KeyB', 2)
+				await expectToBePrevented('KeyA+KeyB', 0)
+
+				await page.keyboard.up('KeyA')
+				await page.keyboard.up('KeyB')
+				await expectToTrigger('KeyA+KeyB', 2)
+				await expectToBePrevented('KeyA+KeyB', 0)
 			})
 		})
 	})

--- a/src/__tests__/bind.test.ts
+++ b/src/__tests__/bind.test.ts
@@ -945,7 +945,7 @@ describe('Sørensen.bind', () => {
 				await bindCombo('KeyA+KeyB', { preventDefaultDown: false })
 			})
 
-			it('Control+KeyD does trigger preventDefault', async () => {
+			it('Control+KeyD does not trigger preventDefault', async () => {
 				await expectToTrigger('Control+KeyD', 0)
 				await expectToBePrevented('Control+KeyD', 0)
 

--- a/src/__tests__/utils/bindCombo.ts
+++ b/src/__tests__/utils/bindCombo.ts
@@ -15,6 +15,12 @@ export async function expectToTrigger(combo: string, count: number) {
 	})
 }
 
+export async function expectToBePrevented(combo: string, count: number) {
+	await expectPuppet(page).toMatchElement(`#result .binding[data-combo="${combo}"] .defaultPrevented`, {
+		text: count.toString(),
+	})
+}
+
 export async function resetCombo(combo: string) {
 	await page.evaluate<string>(`resetState(${JSON.stringify(combo)})`)
 }

--- a/src/__tests__/windowFocus.test.ts
+++ b/src/__tests__/windowFocus.test.ts
@@ -68,7 +68,7 @@ describe('Window focus handling', () => {
 			await page.evaluate(() => window.dispatchEvent(new Event('blur')))
 
 			expect(await getPressedKeys()).toHaveLength(0)
-			expect(await page.$("#cancelled-keys").then((el) => el?.evaluate(el => el.innerHTML))).toBe(',KeyB')
+			expect(await page.$('#cancelled-keys').then((el) => el?.evaluate((el) => el.innerHTML))).toBe(',KeyB')
 			await page.evaluate(() => window.dispatchEvent(new Event('focus')))
 			await page.keyboard.up('KeyB')
 			await expectToTrigger('KeyB', 2)

--- a/src/index.ts
+++ b/src/index.ts
@@ -307,7 +307,7 @@ function isAllowedToExecute(binding: ComboBinding, e: KeyboardEvent): boolean {
 	) {
 		return false
 	} else if (typeof binding.global === 'function') {
-		return binding.global(e, stringifyCombo(binding.combo))
+		return !!binding.global(e, stringifyCombo(binding.combo))
 	}
 	return true
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -409,9 +409,6 @@ function registerPreventDefaultDownKey(_key: string, _e: KeyboardEvent) {
 		if (!chord.binding.preventDefaultDown) {
 			return
 		}
-		if (chord.binding.combo.length !== chord.note) {
-			return
-		}
 		matchNote(chord.binding.combo[chord.note], keysDown, chord.binding, ignoredKeys)
 	})
 	bound.forEach((binding) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -411,7 +411,11 @@ function registerPreventDefaultDownKeys(_key: string, _e: KeyboardEvent) {
 		if (!chord.binding.preventDefaultDown) {
 			return
 		}
-		matchNote(chord.binding.combo[chord.note], keysDown, chord.binding, ignoredKeys)
+		const ignoredChordKeys: string[] = []
+		const matched = matchNote(chord.binding.combo[chord.note], keysDown, chord.binding, ignoredChordKeys)
+		if (matched) {
+			ignoredKeys.push(...ignoredChordKeys)
+		}
 	})
 	bound.forEach((binding) => {
 		if (!binding.preventDefaultDown) {
@@ -420,7 +424,11 @@ function registerPreventDefaultDownKeys(_key: string, _e: KeyboardEvent) {
 		if (binding.combo.length !== 1) {
 			return
 		}
-		matchNote(binding.combo[0], keysDown, binding, ignoredKeys)
+		const ignoredChordKeys: string[] = []
+		const matched = matchNote(binding.combo[0], keysDown, binding, ignoredChordKeys)
+		if (matched) {
+			ignoredKeys.push(...ignoredChordKeys)
+		}
 	})
 	keyRepeatIgnoreKeys = [...keyRepeatIgnoreKeys, ...Array.from(new Set(ignoredKeys))]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -405,7 +405,7 @@ function visitChordsInProgress(key: string, up: boolean, e: KeyboardEvent) {
 	chordsInProgress = chordsInProgress.filter((chord) => !notInProgress.includes(chord))
 }
 
-function registerPreventDefaultDownKey(_key: string, _e: KeyboardEvent) {
+function registerPreventDefaultDownKeys(_key: string, _e: KeyboardEvent) {
 	const ignoredKeys: string[] = []
 	chordsInProgress.forEach((chord) => {
 		if (!chord.binding.preventDefaultDown) {
@@ -507,7 +507,7 @@ function keyDown(e: KeyboardEvent) {
 			e = overloadEventStopImmediatePropagation(e)
 			visitChordsInProgress(e.code, false, e)
 			visitBoundCombos(e.code, false, e)
-			registerPreventDefaultDownKey(e.code, e)
+			registerPreventDefaultDownKeys(e.code, e)
 		}
 		cleanUpFinishedChords()
 		clearChordTimeout()

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ export interface BindOptions {
 	 * Prevent default behavior on key down.
 	 * Default: `true`
 	 */
-	preventDefaultDown?: boolean 
+	preventDefaultDown?: boolean
 
 	/**
 	 * Insert this binding at the top of the bindings list, allowing it to prevent other bindings from running by
@@ -268,7 +268,12 @@ function matchNoteOrdered(combo: Note, keysToMatch: string[], options: BindOptio
 	return true
 }
 
-function matchNoteUnordered(combo: Note, keysToMatch: string[], _options: BindOptions, outIgnoredKeys: string[]): boolean {
+function matchNoteUnordered(
+	combo: Note,
+	keysToMatch: string[],
+	_options: BindOptions,
+	outIgnoredKeys: string[]
+): boolean {
 	for (let i = 0; i < combo.length; i++) {
 		const code = combo[i]
 		if (code in VIRTUAL_ANY_POSITION_KEYS) {
@@ -292,7 +297,6 @@ function matchNoteUnordered(combo: Note, keysToMatch: string[], _options: BindOp
 	}
 	return true
 }
-
 
 function isAllowedToExecute(binding: ComboBinding, e: KeyboardEvent): boolean {
 	if (
@@ -323,8 +327,8 @@ function callListenerIfAllowed(binding: ComboBinding, e: KeyboardEvent, note = 0
 				if ((e as any)[SORENSEN_IMMEDIATE_PROPAGATION_STOPPED]) {
 					return
 				}
-				; (e as any)[SORENSEN_IMMEDIATE_PROPAGATION_STOPPED] = true
-				; (e as any)[SORENSEN_STOP_IMMEDIATE_PROPAGATION]()
+				;(e as any)[SORENSEN_IMMEDIATE_PROPAGATION_STOPPED] = true
+				;(e as any)[SORENSEN_STOP_IMMEDIATE_PROPAGATION]()
 			},
 		})
 	)
@@ -344,7 +348,7 @@ function visitBoundCombos(key: string, up: boolean, e: KeyboardEvent) {
 			matchNote(binding.combo[0], up ? [...keysDown, key] : keysDown, binding, ignoredKeys) &&
 			(binding.up ?? false) === up
 		) {
-				if (chordsInProgressCount === 0 || binding.exclusive === false) {
+			if (chordsInProgressCount === 0 || binding.exclusive === false) {
 				if (binding.combo.length === 1) {
 					// DEBUG: console.log(binding, chordsInProgress, binding.exclusive)
 					callListenerIfAllowed(binding, e, 0)
@@ -376,9 +380,7 @@ function visitChordsInProgress(key: string, up: boolean, e: KeyboardEvent) {
 			return
 		}
 		const ignoredKeys: string[] = []
-		if (
-			matchNote(chord.binding.combo[chord.note], up ? [...keysDown, key] : keysDown, chord.binding, ignoredKeys)
-		) {
+		if (matchNote(chord.binding.combo[chord.note], up ? [...keysDown, key] : keysDown, chord.binding, ignoredKeys)) {
 			chord.note = chord.note + 1
 			// DEBUG: console.log('Did match', chord)
 			if (chord.binding.combo.length === chord.note) {
@@ -550,9 +552,11 @@ function clearPressedKeys(): void {
 	// inform potential listeners about cancelled keys
 	const cancelledKeys = keysDown.slice()
 	keysDown.length = 0
-	cancelledKeys.forEach((code) => dispatchEvent("keycancel", {
-		code
-	}))
+	cancelledKeys.forEach((code) =>
+		dispatchEvent('keycancel', {
+			code,
+		})
+	)
 	poisoned = false
 }
 

--- a/test/index.html
+++ b/test/index.html
@@ -22,6 +22,9 @@
 		<div class="hit">
 			<!-- Was activated? -->
 		</div>
+		<div class="defaultPrevented">
+			<!-- Was preventDefault called? -->
+		</div>
 	</div>
 </template>
 <h1>Sørensen test playground</h1>
@@ -82,6 +85,7 @@
 			const bindRow = template.content.cloneNode(true)
 			bindRow.querySelector('.combo').textContent = combo
 			bindRow.querySelector('.hit').textContent = (0).toString()
+			bindRow.querySelector('.defaultPrevented').textContent = (0).toString()
 			document.getElementById('result').appendChild(bindRow)
 			const inserted = document.getElementById('result').lastElementChild
 			inserted.dataset['combo'] = combo
@@ -91,6 +95,17 @@
 					const hitCell = inserted.querySelector('.hit')
 					hitCell.textContent = (Number(hitCell.textContent) || 0) + 1
 					hitCell.classList.add('hot')
+					const origPreventDefault = e.preventDefault
+					const defaultPreventedCell = inserted.querySelector('.defaultPrevented')
+					const nextDefaultPrevented = (Number(defaultPreventedCell.textContent) || 0) + Number(options.preventDefaultDown ?? false)
+					
+					e.preventDefault = () => {
+							if (e.defaultPreventedDown) {
+								defaultPreventedCell.textContent = nextDefaultPrevented
+							}
+							origPreventDefault.call(e)
+					}
+					defaultPreventedCell.classList.add('hot')
 					if (typeof clb === 'function') clb(e)
 				},
 				options
@@ -100,10 +115,12 @@
 		const resetState = (combo) => {
 			document.querySelector(`.binding[data-combo="${combo}"] .hit`).textContent = (0).toString()
 			document.querySelector(`.binding[data-combo="${combo}"] .hit`).classList.remove('hot')
+			document.querySelector(`.binding[data-combo="${combo}"] .defaultPrevented`).textContent = (0).toString()
+			document.querySelector(`.binding[data-combo="${combo}"] .defaultPrevented`).classList.remove('hot')
 		}
 
 		const resetAllStates = () => {
-			const allStates = document.querySelectorAll(`.binding .hit`)
+			const allStates = document.querySelectorAll(`.binding .hit, .binding .defaultPrevented`)
 			allStates.forEach((element) => {
 				element.textContent = (0).toString()
 				element.classList.remove('hot')


### PR DESCRIPTION
The option `preventDefaultDown: true` prevents the default behaviour on a note basis on keyDown events for both keyUp and keyDown bindings.

It is introduced to accommodate the need for overriding default behavior for keyUp-bound shortcuts that a browser triggers on keyDown, like `F11` and `Control+KeyD`.

The PR also contains a bit of refactoring for decreasing function complexity and improve readability.

*Note: In the commit message https://github.com/nrkno/sorensen/commit/7fcbdd65d01eebc7079ca0fcec4b55444e842fee, chord should be replaced with note.*