### PR TITLE
fix: add additional check for navigator.keyboard

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -547,7 +547,7 @@ function windowBlur() {
 }
 
 async function getKeyboardLayoutMap() {
-	if ('keyboard' in navigator && typeof navigator.keyboard.getLayoutMap === 'function') {
+	if ('keyboard' in navigator && navigator.keyboard && typeof navigator.keyboard.getLayoutMap === 'function') {
 		try {
 			keyboardLayoutMap = await navigator.keyboard.getLayoutMap()
 			dispatchEvent('layoutchange')
@@ -658,7 +658,7 @@ async function init(options?: { chordTimeout?: number }) {
 		window.addEventListener('blur', windowBlur)
 		window.addEventListener('pagehide', windowBlur)
 
-		if ('keyboard' in navigator && typeof navigator.keyboard.addEventListener === 'function') {
+		if ('keyboard' in navigator && navigator.keyboard && typeof navigator.keyboard.addEventListener === 'function') {
 			navigator.keyboard.addEventListener('layoutchange', getKeyboardLayoutMap)
 		}
 		await getKeyboardLayoutMap()
@@ -685,7 +685,7 @@ async function destroy() {
 		window.removeEventListener('blur', windowBlur)
 		window.removeEventListener('pagehide', windowBlur)
 
-		if ('keyboard' in navigator && typeof navigator.keyboard.removeEventListener === 'function') {
+		if ('keyboard' in navigator && navigator.keyboard && typeof navigator.keyboard.removeEventListener === 'function') {
 			navigator.keyboard.removeEventListener('layoutchange', getKeyboardLayoutMap)
 		}
 


### PR DESCRIPTION
I noticed this error pops up in our Sofie logs from time to time:

```
Client error, Sorensen.init, TypeError: TypeError: Cannot read properties of undefined (reading 'addEventListener'), TypeError: Cannot read properties of undefined (reading 'addEventListener')
``` 
The error originates from https://github.com/nrkno/sorensen/blob/main/src/index.ts#L661

I have no more info than this, but it seems that `navigator.keyboard` must have been set, but have the value `undefined` in some browser?

Anyway, this fix should fix that issue (fingers crossed).