### PR TITLE
feat: add named export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -750,7 +750,7 @@ function removeEventListener(event: string, handler: EventHandler | EventHandler
 	}
 }
 
-const sorensen = {
+export const Sorensen = {
 	init,
 	destroy,
 	getCodeForKey,
@@ -763,11 +763,9 @@ const sorensen = {
 	removeEventListener,
 }
 
-export type Sorensen = typeof sorensen
-
 if (window) {
 	//@ts-ignore this is to work around a bug in webpack DevServer
-	window['sorensen'] = sorensen
+	window['sorensen'] = Sorensen
 }
 
-export default sorensen
+export default Sorensen


### PR DESCRIPTION
Using this library in an ESM project using vite can be tricky, as in some configurations it does not get along with commonjs default exports. 

This replaces the type only Sorensen export with a named export of the library, which I think will be backwards compatible, as well as allowing easier importing in ESM