### PR TITLE
fix: prevent event listeners leak

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -679,8 +679,8 @@ async function init(options?: { chordTimeout?: number }) {
  */
 async function destroy() {
 	if (initialized) {
-		window.removeEventListener('keyup', keyUp)
-		window.removeEventListener('keydown', keyDown)
+		window.removeEventListener('keyup', keyUp, { capture: true })
+		window.removeEventListener('keydown', keyDown, { capture: true })
 		window.removeEventListener('visibilitychange', visibilityChange)
 		window.removeEventListener('blur', windowBlur)
 		window.removeEventListener('pagehide', windowBlur)


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix: Prevent event listeners leak

This PR fixes a memory leak where event listeners were not being properly removed from the window object during the `destroy()` function.

### Problem
When adding keyboard event listeners in the `init()` function, both 'keyup' and 'keydown' listeners are registered with `{ capture: true, passive: false }` options. However, when removing these listeners in the `destroy()` function, the removal calls were not specifying the `capture: true` option. According to the DOM specification, event listener removal must use the same options (particularly the `capture` flag) that were used during registration. Without matching the `capture` flag, the listeners are not properly removed, causing them to persist in memory even after `destroy()` is called.

### Solution
Updated the `removeEventListener` calls in the `destroy()` function to include `{ capture: true }` for both 'keyup' and 'keydown' events, matching how they were initially added. This ensures proper cleanup and prevents the event listener leak.

### Changes
- `src/index.ts`: Updated `destroy()` function to specify `{ capture: true }` when removing 'keyup' and 'keydown' event listeners
  - `window.removeEventListener('keyup', keyUp, { capture: true })`
  - `window.removeEventListener('keydown', keyDown, { capture: true })`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->